### PR TITLE
Add multiple tunings for guitar

### DIFF
--- a/music-theory-cheatsheet/app/components/Fretboard.tsx
+++ b/music-theory-cheatsheet/app/components/Fretboard.tsx
@@ -44,7 +44,8 @@ const Fretboard: React.FC<FretboardProps> = ({
                 6: ['C', 'G', 'D', 'A', 'E', 'B']
             },
             guitar: {
-                6: tuning // Use the selected tuning for guitar
+                6: tuning, // Use the selected tuning for guitar
+                7: [...tuning, 'B'] // Example for 7-string guitar
             }
         };
         const fallback = instrument === 'guitar' ? 6 : 4;

--- a/music-theory-cheatsheet/app/components/Fretboard.tsx
+++ b/music-theory-cheatsheet/app/components/Fretboard.tsx
@@ -14,7 +14,8 @@ type FretboardProps = {
     numChords: number,
     useLandmarkNumbers: boolean,
     noteToLandmarkNumber: (note: string) => number | string,
-    instrument: 'bass' | 'guitar'
+    instrument: 'bass' | 'guitar',
+    tuning: string[] // New prop for tuning
 };
 
 type PatternName = string;
@@ -31,7 +32,8 @@ const Fretboard: React.FC<FretboardProps> = ({
     numChords,
     useLandmarkNumbers,
     noteToLandmarkNumber,
-    instrument
+    instrument,
+    tuning // New prop for tuning
 }) => {
     // Function to get the appropriate strings based on numChords
     const getStringsForInstrument = () => {
@@ -42,7 +44,7 @@ const Fretboard: React.FC<FretboardProps> = ({
                 6: ['C', 'G', 'D', 'A', 'E', 'B']
             },
             guitar: {
-                6: ['E', 'A', 'D', 'G', 'B', 'E']
+                6: tuning // Use the selected tuning for guitar
             }
         };
         const fallback = instrument === 'guitar' ? 6 : 4;

--- a/music-theory-cheatsheet/app/components/PatternControls.tsx
+++ b/music-theory-cheatsheet/app/components/PatternControls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 type PatternType = 'scales' | 'arpeggios' | 'chords';
 
@@ -29,7 +29,9 @@ type PatternControlsProps = {
     useLandmarkNumbers: boolean,
     setUseLandmarkNumbers: (use: boolean) => void,
     instrument: 'bass' | 'guitar',
-    setInstrument: (instrument: 'bass' | 'guitar') => void
+    setInstrument: (instrument: 'bass' | 'guitar') => void,
+    tuning: string[], // New prop for tuning
+    setTuning: (tuning: string[]) => void // New prop setter for tuning
 };
 
 const PatternControls: React.FC<PatternControlsProps> = ({
@@ -46,8 +48,24 @@ const PatternControls: React.FC<PatternControlsProps> = ({
     useLandmarkNumbers,
     setUseLandmarkNumbers,
     instrument,
-    setInstrument
+    setInstrument,
+    tuning, // New prop for tuning
+    setTuning // New prop setter for tuning
 }) => {
+    const handleTuningChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const selectedTuning = e.target.value;
+        const tuningMap: Record<string, string[]> = {
+            standard: ['E', 'A', 'D', 'G', 'B', 'E'],
+            dropD: ['D', 'A', 'D', 'G', 'B', 'E'],
+            openG: ['D', 'G', 'D', 'G', 'B', 'D'],
+            openD: ['D', 'A', 'D', 'F#', 'A', 'D'],
+            openE: ['E', 'B', 'E', 'G#', 'B', 'E'],
+            openA: ['E', 'A', 'E', 'A', 'C#', 'E'],
+            openC: ['C', 'G', 'C', 'G', 'C', 'E']
+        };
+        setTuning(tuningMap[selectedTuning]);
+    };
+
     return (
         <div className="mb-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Pattern Type Selection */}
@@ -122,6 +140,26 @@ const PatternControls: React.FC<PatternControlsProps> = ({
                     ))}
                 </select>
             </div>
+
+            {/* Tuning Selection */}
+            {instrument === 'guitar' && (
+                <div className="bg-gray-800 rounded-lg p-4">
+                    <label className="text-gray-300 text-sm mb-2 block">Tuning</label>
+                    <select
+                        value={tuning.join(',')}
+                        onChange={handleTuningChange}
+                        className="w-full bg-gray-700 text-gray-300 p-2 rounded-lg"
+                    >
+                        <option value="standard">Standard</option>
+                        <option value="dropD">Drop D</option>
+                        <option value="openG">Open G</option>
+                        <option value="openD">Open D</option>
+                        <option value="openE">Open E</option>
+                        <option value="openA">Open A</option>
+                        <option value="openC">Open C</option>
+                    </select>
+                </div>
+            )}
 
             {/* Pattern Selection */}
             <div className="bg-gray-800 rounded-lg p-4 col-span-2">

--- a/music-theory-cheatsheet/app/components/PatternControls.tsx
+++ b/music-theory-cheatsheet/app/components/PatternControls.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 type PatternType = 'scales' | 'arpeggios' | 'chords';
 

--- a/music-theory-cheatsheet/app/page.tsx
+++ b/music-theory-cheatsheet/app/page.tsx
@@ -87,6 +87,26 @@ const InteractiveBassDisplay = () => {
             'Locrian': {
                 intervals: [0, 1, 3, 5, 6, 8, 10],
                 description: 'Diminished scale'
+            },
+            'Harmonic Minor': {
+                intervals: [0, 2, 3, 5, 7, 8, 11],
+                description: 'Minor scale with raised 7th'
+            },
+            'Melodic Minor': {
+                intervals: [0, 2, 3, 5, 7, 9, 11],
+                description: 'Minor scale with raised 6th and 7th'
+            },
+            'Pentatonic Major': {
+                intervals: [0, 2, 4, 7, 9],
+                description: 'Five-note major scale'
+            },
+            'Pentatonic Minor': {
+                intervals: [0, 3, 5, 7, 10],
+                description: 'Five-note minor scale'
+            },
+            'Blues Scale': {
+                intervals: [0, 3, 5, 6, 7, 10],
+                description: 'Minor pentatonic with added ♭5'
             }
         },
         arpeggios: {
@@ -280,6 +300,11 @@ const InteractiveBassDisplay = () => {
                                 <li>Mixolydian: Major with ♭7 (1 2 3 4 5 6 ♭7)</li>
                                 <li>Aeolian: Natural minor (1 2 ♭3 4 5 ♭6 ♭7)</li>
                                 <li>Locrian: Diminished (1 ♭2 ♭3 4 ♭5 ♭6 ♭7)</li>
+                                <li>Harmonic Minor: Minor with raised 7th (1 2 ♭3 4 5 ♭6 7)</li>
+                                <li>Melodic Minor: Minor with raised 6th and 7th (1 2 ♭3 4 5 6 7)</li>
+                                <li>Pentatonic Major: Five-note major scale (1 2 3 5 6)</li>
+                                <li>Pentatonic Minor: Five-note minor scale (1 ♭3 4 5 ♭7)</li>
+                                <li>Blues Scale: Minor pentatonic with added ♭5 (1 ♭3 4 ♭5 5 ♭7)</li>
                             </ul>
                         </div>
                     </div>

--- a/music-theory-cheatsheet/app/page.tsx
+++ b/music-theory-cheatsheet/app/page.tsx
@@ -36,6 +36,7 @@ const InteractiveBassDisplay = () => {
     const [numChords, setNumChords] = useState<number>(4); // Default to 4 chords
     const [useLandmarkNumbers, setUseLandmarkNumbers] = useState(false);
     const [instrument, setInstrument] = useState<'bass' | 'guitar'>('bass'); // New state variable for instrument
+    const [tuning, setTuning] = useState<string[]>(['E', 'A', 'D', 'G', 'B', 'E']); // New state variable for tuning
 
     // Bass strings from highest to lowest
     const strings = ['G', 'D', 'A', 'E'];
@@ -201,6 +202,8 @@ const InteractiveBassDisplay = () => {
                     setUseLandmarkNumbers={setUseLandmarkNumbers}
                     instrument={instrument} // Pass new state
                     setInstrument={setInstrument} // Pass new state setter
+                    tuning={tuning} // Pass new state
+                    setTuning={setTuning} // Pass new state setter
                 />
 
                 {/* Theory Toggle */}
@@ -227,6 +230,7 @@ const InteractiveBassDisplay = () => {
                     useLandmarkNumbers={useLandmarkNumbers}
                     noteToLandmarkNumber={noteToLandmarkNumber}
                     instrument={instrument} // Pass new state
+                    tuning={tuning} // Pass new state
                 />
 
                 {/* Theory Information */}

--- a/music-theory-cheatsheet/app/utils/musicTheory.ts
+++ b/music-theory-cheatsheet/app/utils/musicTheory.ts
@@ -34,5 +34,9 @@ export const guitarTheory = {
     openD: ['D', 'A', 'D', 'F#', 'A', 'D'],
     openE: ['E', 'B', 'E', 'G#', 'B', 'E'],
     openA: ['E', 'A', 'E', 'A', 'C#', 'E'],
-    openC: ['C', 'G', 'C', 'G', 'C', 'E']
+    openC: ['C', 'G', 'C', 'G', 'C', 'E'],
+    dadgad: ['D', 'A', 'D', 'G', 'A', 'D'],
+    doubleDropD: ['D', 'A', 'D', 'G', 'B', 'D'],
+    halfStepDown: ['Eb', 'Ab', 'Db', 'Gb', 'Bb', 'Eb'],
+    fullStepDown: ['D', 'G', 'C', 'F', 'A', 'D']
 };


### PR DESCRIPTION
Add support for multiple guitar tunings and update components accordingly.

* **Fretboard Component**:
  - Add a new prop `tuning` to handle different tunings.
  - Modify `getStringsForInstrument` to use the selected tuning for guitar.

* **PatternControls Component**:
  - Add a new state variable `tuning` to handle different tunings.
  - Add a dropdown to select different tunings for guitar.
  - Pass the selected tuning to the `Fretboard` component.

* **Page Component**:
  - Add a new state variable `tuning` to handle different tunings.
  - Pass the selected tuning to the `PatternControls` and `Fretboard` components.

* **MusicTheory Utility**:
  - Add multiple guitar tunings to the `guitarTheory` object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/olteanalexandru/Music-theory-cheatsheet/pull/3?shareId=eaa78574-61a7-43ff-bb0e-392e05736d13).